### PR TITLE
Support class names conflict with function properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,17 @@ module.exports.pitch = function(remainingRequest) {
         var classNames = require(${loaderUtils.stringifyRequest(this, '!' + require.resolve('classnames/bind'))});
         var locals = require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)});
         var css = classNames.bind(locals);
-        for (var style in locals) css[style] = locals[style];
+        for (var style in locals) {
+            if (!locals.hasOwnProperty(style)) {
+                continue;
+            }
+            if (typeof Object.defineProperty === 'function') {
+                Object.defineProperty(css, style, {value: locals[style]});
+            }
+            else {
+                css[style] = locals[style];
+            }
+        }
         module.exports = css;
     `;
 }


### PR DESCRIPTION
Previously if we have a css class named `.name` or `.length`, the `css[style] = locals[style]` will fail to override `Function.name` or `Function.length` property since they are not writable, however we can override them via `Object.defineProperty` so `cx.name` can be a correct css module name