### PR TITLE
Support ES module exported class names

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,11 @@ module.exports.pitch = function(remainingRequest) {
     this.cacheable();
     return `
         // classnames-loader: automatically bind css-modules to classnames
+        function interopRequireDefault(obj) {
+            return obj && obj.__esModule ? obj : {default: obj};
+        }
         var classNames = require(${loaderUtils.stringifyRequest(this, '!' + require.resolve('classnames/bind'))});
-        var locals = require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)});
+        var locals = interopRequireDefault(require(${loaderUtils.stringifyRequest(this, '!!' + remainingRequest)})).default;
         var css = classNames.bind(locals);
         for (var style in locals) {
             if (!locals.hasOwnProperty(style)) {
@@ -24,4 +27,4 @@ module.exports.pitch = function(remainingRequest) {
         }
         module.exports = css;
     `;
-}
+};


### PR DESCRIPTION
Having [mini-css-extract-plugin with esModule option](https://github.com/webpack-contrib/mini-css-extract-plugin#esmodule), the exported locals could be like `{default: {foo: 'bar'}, ____esModule: true}`, in this case `classnames-loader` requires an `interopRequireDefault` function to work with it

The `interopRequireDefault` function is exactly copied from `@babel/runtime`